### PR TITLE
Move inactive maintainers to emeritus status

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,4 +5,8 @@
 |-------------------|-----------|----------------|
 | Yongge Wang | [@yonggewang](https://github.com/yonggewang) |  |
 | Ahmed Al Salih | [@ahmed82](https://github.com/ahmed82) |  |
+
+### Emeritus Maintainers
+| name              | Github    | Discord        |
+|-------------------|-----------|----------------|
 | Li Fu | [@xtaci](https://github.com/xtaci) | |


### PR DESCRIPTION
The TSC approved a requirement that maintainers
that have not been active in over three to six
months be move to emeritus status.

These maintainers have not been active in over
one year.

https://github.com/hyperledger/toc/issues/32

Signed-off-by: Ry Jones <ry@linux.com>