### PR TITLE
Allowing append new peers keys

### DIFF
--- a/cmd/emucon/README.md
+++ b/cmd/emucon/README.md
@@ -39,6 +39,7 @@ USAGE:
 OPTIONS:
    --count value   number of participant in quorum (default: 4)
    --config value  output quorum file (default: "./quorum.json")
+   --append value  append key to quorum file (default: 0) 
    --help, -h      show help (default: false)
 
 ```


### PR DESCRIPTION
* Adding the ability to generate and append new peers regenerating the `genkeys --append <int- new peers number>` flag without. Fix the issue of regenerating new keys.
* Also working with the giving --config flag to use another quorum.json file name.